### PR TITLE
Added MainView as the host of all the other views except login&registr

### DIFF
--- a/ThoughtBank.xcodeproj/project.pbxproj
+++ b/ThoughtBank.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7F837F1C2AEEDE14004650ED /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F837F1B2AEEDE14004650ED /* MainView.swift */; };
 		A382322A2AE1AE6D003DB59D /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = A38232292AE1AE6D003DB59D /* FirebaseAnalytics */; };
 		A382322C2AE1AE6D003DB59D /* FirebaseAnalyticsOnDeviceConversion in Frameworks */ = {isa = PBXBuildFile; productRef = A382322B2AE1AE6D003DB59D /* FirebaseAnalyticsOnDeviceConversion */; };
 		A382322E2AE1AE6D003DB59D /* FirebaseAnalyticsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A382322D2AE1AE6D003DB59D /* FirebaseAnalyticsSwift */; };
@@ -55,6 +56,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		7F837F1B2AEEDE14004650ED /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		A38232612AE1ED2B003DB59D /* AddThoughtsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddThoughtsView.swift; sourceTree = "<group>"; };
 		A38232672AE1F067003DB59D /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		A3CE61D82ADF2B9D0039EC83 /* ThoughtBank.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ThoughtBank.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -191,6 +193,7 @@
 				FFB71AE52ADF51150006C762 /* PersonalThoughtsView.swift */,
 				FFB71AE02ADF51140006C762 /* DepositedThoughtsView.swift */,
 				FFB71AE42ADF51140006C762 /* SettingsView.swift */,
+				7F837F1B2AEEDE14004650ED /* MainView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -307,6 +310,7 @@
 				FFB71ADD2ADF51030006C762 /* ViewModelProtocol.swift in Sources */,
 				FFB71AEA2ADF51150006C762 /* LoginView.swift in Sources */,
 				A38232622AE1ED2B003DB59D /* AddThoughtsView.swift in Sources */,
+				7F837F1C2AEEDE14004650ED /* MainView.swift in Sources */,
 				FFB71ADC2ADF51030006C762 /* CentralViewModel.swift in Sources */,
 				FFB71AE82ADF51150006C762 /* LandingPageView.swift in Sources */,
 				FFB71AE92ADF51150006C762 /* MainFeedView.swift in Sources */,

--- a/ThoughtBank/View/AddThoughtsView.swift
+++ b/ThoughtBank/View/AddThoughtsView.swift
@@ -12,7 +12,11 @@ struct AddThoughtsView<ViewModel: ViewModelProtocol>: View {
     
     
     var body: some View {
-        Text(viewModel.description)
+        VStack {
+            Text(viewModel.description)
+            Text("This is AddThoughtsView")
+        }
+        
     }
 }
 

--- a/ThoughtBank/View/DepositedThoughtsView.swift
+++ b/ThoughtBank/View/DepositedThoughtsView.swift
@@ -18,7 +18,11 @@ struct DepositedThoughtsView<ViewModel: ViewModelProtocol>: View {
     @EnvironmentObject var viewModel: ViewModel
     
     var body: some View {
-        Text(viewModel.description)
+        VStack {
+            Text(viewModel.description)
+            Text("This is DepositedThoughtsView")
+        }
+        
     }
 }
 

--- a/ThoughtBank/View/LandingPageView.swift
+++ b/ThoughtBank/View/LandingPageView.swift
@@ -20,7 +20,11 @@ struct LandingPageView<ViewModel: ViewModelProtocol>: View {
     @EnvironmentObject var viewModel: ViewModel
     
     var body: some View {
-        Text(viewModel.description)
+        VStack {
+            Text(viewModel.description)
+            Text("This is LandingPageView")
+        }
+        
     }
 }
 

--- a/ThoughtBank/View/MainFeedView.swift
+++ b/ThoughtBank/View/MainFeedView.swift
@@ -18,7 +18,11 @@ struct MainFeedView<ViewModel: ViewModelProtocol>: View {
     @EnvironmentObject var viewModel: ViewModel
     
     var body: some View {
-        Text(viewModel.description)
+        VStack {
+            Text(viewModel.description)
+            Text("This is MainFeedView")
+        }
+        
     }
 }
 

--- a/ThoughtBank/View/MainView.swift
+++ b/ThoughtBank/View/MainView.swift
@@ -1,0 +1,92 @@
+//
+//  MainView.swift
+//  ThoughtBank
+//
+//  Created by Songyuan Liu on 10/29/23.
+//
+
+import SwiftUI
+
+enum LandingPageOption {
+    case Public, Personal, Saved
+}
+
+struct MainView<ViewModel: ViewModelProtocol>: View {
+    @State var landingPageOption: String
+    
+    let LandingPageOptions = ["Public", "Personal", "Saved"]
+   
+    var body: some View {
+        NavigationStack {
+            Divider()
+            VStack {
+                Picker("hello", selection: $landingPageOption) {
+                    ForEach(LandingPageOptions, id: \.self) {
+                        Text($0)
+                    }
+                }
+                .pickerStyle(.segmented)
+                
+            }
+            .frame(minWidth: 0, maxWidth: 350, minHeight: 0, maxHeight: 50)
+            
+            TabView {
+                MainFeedView<PreviewViewModel>()
+                    .tabItem {
+                        Label("Browse", systemImage: "magnifyingglass.circle")
+                    }
+                
+                DepositedThoughtsView<PreviewViewModel>()
+                    .tabItem {
+                        Label("My Notes", systemImage: "house")
+                    }
+                
+                AddThoughtsView<PreviewViewModel>()
+                    .tabItem {
+                        Label("Share", systemImage: "square.and.arrow.up")
+                    }
+                
+                LandingPageView<PreviewViewModel>()
+                    .tabItem {
+                        Label("Search", systemImage: "magnifyingglass")
+                    }
+                
+                SettingsView<PreviewViewModel>()
+                    .tabItem {
+                        Label("Settings", systemImage: "gearshape")
+                    }
+            }
+            .toolbar {
+                Button {
+                    
+                } label: {
+                    Label("Bookmark", systemImage: "textformat.size")
+                        
+                }
+            }
+            .toolbar {
+                Button {
+                    
+                } label: {
+                    Label("Bookmark", systemImage: "speaker.wave.2")
+                }
+            }
+            .toolbar {
+                Button {
+                    
+                } label: {
+                    Label("Bookmark", systemImage: "bookmark")
+                }
+                
+            }
+
+        }
+        
+        
+    }
+}
+
+#Preview {
+    MainView<PreviewViewModel>(landingPageOption: "Public")
+        .environmentObject(PreviewViewModel())
+}

--- a/ThoughtBank/View/PersonalThoughtsView.swift
+++ b/ThoughtBank/View/PersonalThoughtsView.swift
@@ -18,7 +18,10 @@ struct PersonalThoughtsView<ViewModel: ViewModelProtocol>: View {
     @EnvironmentObject var viewModel: ViewModel
     
     var body: some View {
-        Text(viewModel.description)
+        VStack{
+            Text(viewModel.description)
+            Text("This is PersonalThoughtsView")
+        }
     }
 }
 

--- a/ThoughtBank/View/SettingsView.swift
+++ b/ThoughtBank/View/SettingsView.swift
@@ -18,7 +18,11 @@ struct SettingsView<ViewModel: ViewModelProtocol>: View {
     @EnvironmentObject var viewModel: ViewModel
     
     var body: some View {
-        Text(viewModel.description)
+        VStack {
+            Text(viewModel.description)
+            Text("This is SettingsView")
+        }
+        
     }
 }
 


### PR DESCRIPTION
Inside MainView: 
1. Created a navigation bar at the bottom of the screen that allows users to switch between different views. 
2. Created a toolbar at the upper right of the screen that currently doesn't implement button logics
3. Created a segmented picker below the toolbar that currently doesn't implement switch logics. (Due to the fact that to which screen does clicking Public, Personal or Saved lead is unclear)
The MainView should be the new landing page after user authetication process succeeds. 