### PR TITLE
Added MainView

### DIFF
--- a/ThoughtBank.xcodeproj/project.pbxproj
+++ b/ThoughtBank.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		3D5E89272AEF137D00C74079 /* KeyboardAdaptive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D5E89262AEF137D00C74079 /* KeyboardAdaptive.swift */; };
+		7F1890132AEFF99E0099539B /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F1890122AEFF99E0099539B /* MainView.swift */; };
 		A382322A2AE1AE6D003DB59D /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = A38232292AE1AE6D003DB59D /* FirebaseAnalytics */; };
 		A382322C2AE1AE6D003DB59D /* FirebaseAnalyticsOnDeviceConversion in Frameworks */ = {isa = PBXBuildFile; productRef = A382322B2AE1AE6D003DB59D /* FirebaseAnalyticsOnDeviceConversion */; };
 		A382322E2AE1AE6D003DB59D /* FirebaseAnalyticsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A382322D2AE1AE6D003DB59D /* FirebaseAnalyticsSwift */; };
@@ -57,6 +58,7 @@
 
 /* Begin PBXFileReference section */
 		3D5E89262AEF137D00C74079 /* KeyboardAdaptive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardAdaptive.swift; sourceTree = "<group>"; };
+		7F1890122AEFF99E0099539B /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		A38232612AE1ED2B003DB59D /* AddThoughtsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddThoughtsView.swift; sourceTree = "<group>"; };
 		A38232672AE1F067003DB59D /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		A3CE61D82ADF2B9D0039EC83 /* ThoughtBank.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ThoughtBank.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -202,6 +204,7 @@
 				FFB71AE52ADF51150006C762 /* PersonalThoughtsView.swift */,
 				FFB71AE02ADF51140006C762 /* DepositedThoughtsView.swift */,
 				FFB71AE42ADF51140006C762 /* SettingsView.swift */,
+				7F1890122AEFF99E0099539B /* MainView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -320,6 +323,7 @@
 				FFB71AEA2ADF51150006C762 /* LoginView.swift in Sources */,
 				A38232622AE1ED2B003DB59D /* AddThoughtsView.swift in Sources */,
 				FFB71ADC2ADF51030006C762 /* CentralViewModel.swift in Sources */,
+				7F1890132AEFF99E0099539B /* MainView.swift in Sources */,
 				FFB71AE82ADF51150006C762 /* LandingPageView.swift in Sources */,
 				FFB71AE92ADF51150006C762 /* MainFeedView.swift in Sources */,
 				A3CE61DC2ADF2B9D0039EC83 /* ThoughtBankApp.swift in Sources */,

--- a/ThoughtBank/View/MainView.swift
+++ b/ThoughtBank/View/MainView.swift
@@ -1,0 +1,91 @@
+//
+//  MainView.swift
+//  ThoughtBank
+//
+//  Created by Songyuan Liu on 10/29/23.
+//
+
+import SwiftUI
+
+enum LandingPageOption {
+    case Public, Personal, Saved
+}
+
+struct MainView<ViewModel: ViewModelProtocol>: View {
+    @State var landingPageOption: String
+    
+    let LandingPageOptions = ["Public", "Personal", "Saved"]
+
+    var body: some View {
+        NavigationStack {
+            Divider()
+            VStack {
+                Picker("hello", selection: $landingPageOption) {
+                    ForEach(LandingPageOptions, id: \.self) {
+                        Text($0)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+            .frame(minWidth: 0, maxWidth: 350, minHeight: 0, maxHeight: 50)
+            
+            TabView {
+                MainFeedView<PreviewViewModel>()
+                    .tabItem {
+                        Label("Browse", systemImage: "magnifyingglass.circle")
+                    }
+                
+                DepositedThoughtsView<PreviewViewModel>()
+                    .tabItem {
+                        Label("My Notes", systemImage: "house")
+                    }
+                
+                AddThoughtsView<PreviewViewModel>()
+                    .tabItem {
+                        Label("Share", systemImage: "square.and.arrow.up")
+                    }
+                
+                LandingPageView<PreviewViewModel>()
+                    .tabItem {
+                        Label("Search", systemImage: "magnifyingglass")
+                    }
+                
+                SettingsView<PreviewViewModel>()
+                    .tabItem {
+                        Label("Settings", systemImage: "gearshape")
+                    }
+            }
+            .toolbar {
+                Button {
+                    
+                } label: {
+                    Label("Bookmark", systemImage: "textformat.size")
+                        
+                }
+            }
+            .toolbar {
+                Button {
+                    
+                } label: {
+                    Label("Bookmark", systemImage: "speaker.wave.2")
+                }
+            }
+            .toolbar {
+                Button {
+                    
+                } label: {
+                    Label("Bookmark", systemImage: "bookmark")
+                }
+                
+            }
+
+        }
+        
+        
+    }
+}
+
+#Preview {
+    MainView<PreviewViewModel>(landingPageOption: "Public")
+        .environmentObject(PreviewViewModel())
+}

--- a/ThoughtBank/View/MainView.swift
+++ b/ThoughtBank/View/MainView.swift
@@ -12,6 +12,7 @@ enum LandingPageOption {
 }
 
 struct MainView<ViewModel: ViewModelProtocol>: View {
+    @EnvironmentObject var viewModel: ViewModel
     @State var landingPageOption: String
     
     let LandingPageOptions = ["Public", "Personal", "Saved"]
@@ -30,27 +31,27 @@ struct MainView<ViewModel: ViewModelProtocol>: View {
             .frame(minWidth: 0, maxWidth: 350, minHeight: 0, maxHeight: 50)
             
             TabView {
-                MainFeedView<PreviewViewModel>()
+                MainFeedView<CentralViewModel>()
                     .tabItem {
                         Label("Browse", systemImage: "magnifyingglass.circle")
                     }
                 
-                DepositedThoughtsView<PreviewViewModel>()
+                DepositedThoughtsView<CentralViewModel>()
                     .tabItem {
                         Label("My Notes", systemImage: "house")
                     }
                 
-                AddThoughtsView<PreviewViewModel>()
+                AddThoughtsView<CentralViewModel>()
                     .tabItem {
                         Label("Share", systemImage: "square.and.arrow.up")
                     }
                 
-                LandingPageView<PreviewViewModel>()
+                LandingPageView<CentralViewModel>()
                     .tabItem {
                         Label("Search", systemImage: "magnifyingglass")
                     }
                 
-                SettingsView<PreviewViewModel>()
+                SettingsView<CentralViewModel>()
                     .tabItem {
                         Label("Settings", systemImage: "gearshape")
                     }
@@ -85,7 +86,8 @@ struct MainView<ViewModel: ViewModelProtocol>: View {
     }
 }
 
-#Preview {
-    MainView<PreviewViewModel>(landingPageOption: "Public")
-        .environmentObject(PreviewViewModel())
+struct MainView_Previews: PreviewProvider {
+    static var previews: some View {
+        MainView<PreviewViewModel>(landingPageOption: "Public").environmentObject(PreviewViewModel())
+    }
 }


### PR DESCRIPTION
Inside Mainview:

1. Added a toolbar on the upper right corner with 3 buttons that currently don't have any actions
2. Added a segmented picker below the toolbar with 3 options (Public, Personal, Saved) that currently doesn't have the ability to go to another view when Personal or Saved is clicked. Another problem associated with that is this picker is on every screen but it's supposed to only live in Mainfeed/Personal/Deposited views. Haven't found a way to resovle this issue yet.
3. Added a navigation bar at the bottom that allows users to switch between views. 